### PR TITLE
Complete delete functionality, also use db id to retreive files rathe…

### DIFF
--- a/app/client/src/api.js
+++ b/app/client/src/api.js
@@ -105,6 +105,14 @@ export const uploadService = {
     });
   },
 
+  deleteFile: async (id) => {
+    return await fetchWithAuth(`/upload/file/${id}`, { method: "DELETE" });
+  },
+
+  deleteText: async (id) => {
+    return await fetchWithAuth(`/upload/text/${id}`, { method: "DELETE" });
+  },
+
   getFileUploads: async () => {
     return await fetchWithAuth("/upload/file");
   },
@@ -117,18 +125,19 @@ export const uploadService = {
     return await fetchWithAuth(`/upload/text/${id}`);
   },
 
-  getSignedUrl: async (s3Key) => {
-    return await fetchWithAuth(`/upload/signed-url?key=${encodeURIComponent(s3Key)}`);
-  },
-
-  downloadFile: async (s3Key) => {
-    const url = `${apiConfig.baseUrlAPI}/upload/download?key=${encodeURIComponent(s3Key)}`;
+  downloadFile: async (id) => {
+    const url = `${apiConfig.baseUrlAPI}/upload/download/${id}`;
     const token = getCsrfToken();
     const response = await fetch(url, {
       credentials: "include",
       headers: token ? { "X-CSRF-Token": token } : {},
     });
-    if (!response.ok) throw new Error("Download failed");
+    if (!response.ok) {
+      const data = await response.json();
+      const error = new Error(data.error || "Download failed");
+      error.response = { status: response.status, data };
+      throw error;
+    }
     return response.blob();
   },
 };

--- a/app/client/src/pages/Upload.js
+++ b/app/client/src/pages/Upload.js
@@ -7,6 +7,7 @@ import {
 import DownloadIcon from "@mui/icons-material/Download";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import DeleteIcon from "@mui/icons-material/Delete";
 import { uploadService } from "../api.js";
 import { useAuth } from "../context/AuthContext.js";
 import PageCard from "../components/PageCard.js";
@@ -146,6 +147,9 @@ export default function Upload() {
   const [viewTextDialog, setViewTextDialog] = useState(null);
   const [viewFileDialog, setViewFileDialog] = useState(null);
 
+  const [deletingId, setDeletingId] = useState(null);
+  const [confirmDelete, setConfirmDelete] = useState(null);
+
   const showFileMessage = (type, text) => {
     setFileMessage({ type, text });
     setTimeout(() => setFileMessage(null), 5000);
@@ -222,10 +226,10 @@ export default function Upload() {
     }
   };
 
-  const handleDownload = async (s3Key, fileName) => {
-    setDownloadingKey(s3Key);
+  const handleDownload = async (id, fileName) => {
+    setDownloadingKey(id);
     try {
-      const blob = await uploadService.downloadFile(s3Key);
+      const blob = await uploadService.downloadFile(id);
       const blobUrl = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = blobUrl;
@@ -247,12 +251,13 @@ export default function Upload() {
 
   const handleViewFile = async (f) => {
     setViewFileDialog({
-      fileName: f.File_Name, s3Key: f.S3_Key,
+      fileName: f.File_Name,
+      id: f.File_Upload_ID,
       uploadedAt: formatDate(f.Upload_Time),
       content: null, contentType: null, loading: true, error: null,
     });
     try {
-      const blob = await uploadService.downloadFile(f.S3_Key);
+      const blob = await uploadService.downloadFile(f.File_Upload_ID);
       const ext = f.File_Name.split(".").pop().toLowerCase();
       if (ext === "pdf") {
         const url = URL.createObjectURL(blob);
@@ -271,6 +276,35 @@ export default function Upload() {
       URL.revokeObjectURL(viewFileDialog.content);
     }
     setViewFileDialog(null);
+  };
+
+  const handleDeleteConfirm = (type, id, label) => {
+    setConfirmDelete({ type, id, label });
+  };
+
+  const handleDeleteExecute = async () => {
+    if (!confirmDelete) return;
+    const { type, id } = confirmDelete;
+    setDeletingId(id);
+    setConfirmDelete(null);
+    try {
+      if (type === "file") {
+        await uploadService.deleteFile(id);
+        const res = await uploadService.getFileUploads();
+        setFileHistory(res.uploads || []);
+        showFileMessage("success", "File deleted successfully");
+      } else {
+        await uploadService.deleteText(id);
+        const res = await uploadService.getTextUploads();
+        setTextHistory(res.uploads || []);
+        showTextMessage("success", "Text deleted successfully");
+      }
+    } catch (err) {
+      const msg = err.response?.data?.error || err.message;
+      type === "file" ? showFileMessage("error", msg) : showTextMessage("error", msg);
+    } finally {
+      setDeletingId(null);
+    }
   };
 
   const formatDate = (dateString) =>
@@ -344,12 +378,24 @@ export default function Upload() {
                       <Tooltip title="Download">
                         <IconButton
                           edge="end"
-                          onClick={() => handleDownload(f.S3_Key, f.File_Name)}
-                          disabled={downloadingKey === f.S3_Key}
+                          onClick={() => handleDownload(f.File_Upload_ID, f.File_Name)}
+                          disabled={downloadingKey === f.File_Upload_ID}
                         >
-                          {downloadingKey === f.S3_Key
+                          {downloadingKey === f.File_Upload_ID
                             ? <CircularProgress size={18} />
                             : <DownloadIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Delete">
+                        <IconButton
+                          edge="end"
+                          color="error"
+                          onClick={() => handleDeleteConfirm("file", f.File_Upload_ID, f.File_Name)}
+                          disabled={deletingId === f.File_Upload_ID}
+                        >
+                          {deletingId === f.File_Upload_ID
+                            ? <CircularProgress size={18} />
+                            : <DeleteIcon fontSize="small" />}
                         </IconButton>
                       </Tooltip>
                     </Stack>
@@ -395,11 +441,29 @@ export default function Upload() {
                   key={t.Text_Upload_ID}
                   disableGutters
                   secondaryAction={
-                    <Tooltip title="View">
-                      <IconButton edge="end" onClick={() => handleViewText(t)}>
-                        <VisibilityIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
+                    <Stack direction="row" spacing={0}>
+                      <Tooltip title="View">
+                        <IconButton edge="end" onClick={() => handleViewText(t)}>
+                          <VisibilityIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip title="Delete">
+                        <IconButton
+                          edge="end"
+                          color="error"
+                          onClick={() => handleDeleteConfirm(
+                            "text",
+                            t.Text_Upload_ID,
+                            t.Text_Content.slice(0, 40) + (t.Text_Content.length > 40 ? "…" : "")
+                          )}
+                          disabled={deletingId === t.Text_Upload_ID}
+                        >
+                          {deletingId === t.Text_Upload_ID
+                            ? <CircularProgress size={18} />
+                            : <DeleteIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
+                    </Stack>
                   }
                 >
                   <ListItemText
@@ -422,9 +486,26 @@ export default function Upload() {
         <FileViewDialog
           item={viewFileDialog}
           onClose={handleCloseFileDialog}
-          onDownload={() => handleDownload(viewFileDialog.s3Key, viewFileDialog.fileName)}
-          downloading={downloadingKey === viewFileDialog.s3Key}
+          onDownload={() => handleDownload(viewFileDialog.id, viewFileDialog.fileName)}
+          downloading={downloadingKey === viewFileDialog.id}
         />
+      )}
+      {confirmDelete && (
+        <Dialog open onClose={() => setConfirmDelete(null)} maxWidth="xs" fullWidth>
+          <DialogTitle>Confirm Delete</DialogTitle>
+          <DialogContent>
+            <Typography>
+              Are you sure you want to permanently delete{" "}
+              <strong>{confirmDelete.label}</strong>? This cannot be undone.
+            </Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setConfirmDelete(null)}>Cancel</Button>
+            <Button variant="contained" color="error" onClick={handleDeleteExecute}>
+              Delete
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
     </PageCard>
   );

--- a/app/client/src/pages/Upload.test.js
+++ b/app/client/src/pages/Upload.test.js
@@ -11,6 +11,9 @@ jest.mock("../api.js", () => ({
     getTextUploads: jest.fn(),
     uploadFiles: jest.fn(),
     uploadText: jest.fn(),
+    downloadFile: jest.fn(),
+    deleteFile: jest.fn(),
+    deleteText: jest.fn(),
   },
 }));
 
@@ -40,20 +43,20 @@ describe("Upload component", () => {
 
   test("uploads files and displays success message", async () => {
     uploadService.uploadFiles.mockResolvedValueOnce({ ok: true });
-    
+
     await act(async () => {
       render(<Upload />);
     });
 
     const file = new File(["dummy"], "test.txt", { type: "text/plain" });
     const fileInput = document.getElementById("file-upload");
-    
+
     await act(async () => {
       fireEvent.change(fileInput, { target: { files: [file] } });
     });
 
     const uploadButton = screen.getByRole("button", { name: /Upload Files/i });
-    
+
     await act(async () => {
       fireEvent.click(uploadButton);
     });

--- a/app/server/routes/aiAgent.js
+++ b/app/server/routes/aiAgent.js
@@ -132,7 +132,7 @@ async function fetchPatientRecords(patientUid) {
         const buffer = await s3FileToBuffer(file.S3_Key);
         const content = await extractTextFromFile(buffer, file.File_Name);
         return {
-          id: file.S3_Key,
+          id: file.File_Upload_ID,
           type: "file",
           fileName: file.File_Name,
           content,

--- a/app/server/routes/upload.js
+++ b/app/server/routes/upload.js
@@ -1,6 +1,6 @@
 import express from "express";
 import multer from "multer";
-import { S3Client, PutObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
+import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { v4 as uuidv4 } from "uuid";
 import * as db from "../services/supabaseService.js";
@@ -138,42 +138,61 @@ router.get("/text/:id", async (req, res) => {
   }
 });
 
-// GET /api/upload/signed-url
-router.get("/signed-url", async (req, res) => {
-  const { key } = req.query;
-  if (!key) return res.status(400).json({ error: "key is required" });
+// GET /api/upload/download/:id
+router.get("/download/:id", async (req, res) => {
+  const requesterId = req.user.sub;
+  const { id } = req.params;
 
   try {
+    const record = await db.getFileUploadById(id, requesterId);
+    if (!record) return res.status(403).json({ error: "Not found or access denied" });
+
     const command = new GetObjectCommand({
       Bucket: process.env.AWS_S3_BUCKET_NAME,
-      Key: key,
-    });
-    const url = await getSignedUrl(s3, command, { expiresIn: 300 });
-    res.json({ ok: true, url });
-  } catch (err) {
-    console.error("Error generating signed URL:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
-
-// GET /api/upload/download
-router.get("/download", async (req, res) => {
-  const { key } = req.query;
-  if (!key) return res.status(400).json({ error: "key is required" });
-
-  const fileName = key.split("/").pop();
-
-  try {
-    const command = new GetObjectCommand({
-      Bucket: process.env.AWS_S3_BUCKET_NAME,
-      Key: key,
+      Key: record.S3_Key,
     });
     const s3Response = await s3.send(command);
-    res.setHeader("Content-Disposition", `attachment; filename="${fileName}"`);
+    res.setHeader("Content-Disposition", `attachment; filename="${record.File_Name}"`);
     res.setHeader("Content-Type", s3Response.ContentType || "application/octet-stream");
     s3Response.Body.pipe(res);
   } catch (err) {
     console.error("Download error:", err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /api/upload/file/:id
+router.delete("/file/:id", async (req, res) => {
+  const patientId = req.user.sub;
+  const { id } = req.params;
+
+  try {
+    const record = await db.getFileUploadByIdOwnerOnly(id, patientId);
+    if (!record) return res.status(404).json({ error: "File not found" });
+
+    await s3.send(new DeleteObjectCommand({
+      Bucket: process.env.AWS_S3_BUCKET_NAME,
+      Key: record.S3_Key,
+    }));
+
+    await db.deleteFileUpload(id, patientId);
+    res.json({ ok: true, message: "File deleted successfully" });
+  } catch (err) {
+    console.error("File delete error:", err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// DELETE /api/upload/text/:id
+router.delete("/text/:id", async (req, res) => {
+  const patientId = req.user.sub;
+  const { id } = req.params;
+
+  try {
+    await db.deleteTextUpload(id, patientId);
+    res.json({ ok: true, message: "Text deleted successfully" });
+  } catch (err) {
+    console.error("Text delete error:", err);
     res.status(500).json({ error: err.message });
   }
 });

--- a/app/server/services/supabaseService.js
+++ b/app/server/services/supabaseService.js
@@ -68,6 +68,56 @@ export async function insertFileUpload(fileName, s3Key, patientUid) {
     if (error) throw new Error(error.message);
 }
 
+// Owner-or-provider read — mirrors getTextUploadById for any route that looks up
+// a file record by ID and needs to authorize both the owning patient and their provider
+export async function getFileUploadById(fileUploadId, requesterId) {
+    const { data: record, error } = await supabase
+        .from("File_Upload")
+        .select("File_Upload_ID, S3_Key, File_Name, Patient_UID")
+        .eq("File_Upload_ID", fileUploadId)
+        .single();
+
+    if (error) throw new Error(error.message);
+    if (!record) return null;
+
+    if (record.Patient_UID === requesterId) return record;
+
+    const { data: selection, error: selError } = await supabase
+        .from("Provider_Selection")
+        .select("Provider_Selection_ID")
+        .eq("Patient_UID", record.Patient_UID)
+        .eq("Provider_UID", requesterId)
+        .maybeSingle();
+
+    if (selError) throw new Error(selError.message);
+    if (selection) return record;
+
+    return null;
+}
+
+// Owner-only read — used exclusively by the DELETE route, which needs the S3_Key
+// to remove the object from S3, and must restrict deletion to the patient only
+export async function getFileUploadByIdOwnerOnly(fileUploadId, patientUid) {
+    const { data, error } = await supabase
+        .from("File_Upload")
+        .select("File_Upload_ID, S3_Key, File_Name, Patient_UID")
+        .eq("File_Upload_ID", fileUploadId)
+        .eq("Patient_UID", patientUid)
+        .single();
+
+    if (error) throw new Error(error.message);
+    return data;
+}
+
+export async function deleteFileUpload(fileUploadId, patientUid) {
+    const { error } = await supabase
+        .from("File_Upload")
+        .delete()
+        .eq("File_Upload_ID", fileUploadId)
+        .eq("Patient_UID", patientUid);
+    if (error) throw new Error(error.message);
+}
+
 // ============================================
 // Text Uploads
 // ============================================
@@ -110,5 +160,14 @@ export async function insertTextUpload(text, patientUid) {
         p_text_content: text,
         p_patient_uid: patientUid,
     });
+    if (error) throw new Error(error.message);
+}
+
+export async function deleteTextUpload(textUploadId, patientUid) {
+    const { error } = await supabase
+        .from("Text_Upload")
+        .delete()
+        .eq("Text_Upload_ID", textUploadId)
+        .eq("Patient_UID", patientUid);
     if (error) throw new Error(error.message);
 }


### PR DESCRIPTION
…r than s3 key

# Pull Request — SAACGAS

## Summary
- Summary: Adds delete functionality to the Upload page for both file and text uploads.
  Patients can permanently remove any of their own uploaded files or text entries via a new delete
  button on each history list item, guarded by a confirmation dialog to prevent accidental deletion.
  File deletes remove the object from S3 before removing the database record. On the server, the
  download route is reworked from an unauthenticated key-based endpoint to an ID-based route that
  enforces ownership — verifying the requester is either the owning patient or their selected
  provider before streaming from S3. The S3 key is no longer exposed to or accepted from the client
  in any route. Delete access is restricted to the record owner only; providers can download and
  view but cannot delete a patient's data.

## Related issue(s)
- Closes #51 

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Tests
- [ ] Research/Experiment
- [ ] Other: ______

---

## Security & Privacy Impact (required)

- **Does this change affect** authentication, authorization, encryption, or key management?
  - [X] Yes — explain below
  - [ ] No
- **Does this change process or store user data, model outputs, or secrets?**
  - [X] Yes — explain below
  - [ ] No

If Yes to either: describe what changed and why, list new secrets/keys (if any) and where/how they are stored, and provide mitigation steps and test evidence.

**Security notes / mitigations:**
- Threat model changes (brief): Download route previously accepted any S3 key from any authenticated user with no ownership check. It now uses the DB id to retrieve the S3 key and ensures either the patient is downloading their own record or the patient's provider is. The delete functionality follows the same logic, but only allows the patient themself to delete.
- Cryptography used / changed (algorithms, params): None
- Secrets handling and rotation plan: No change
- Logging/observability changes that affect privacy: No change
