### PR TITLE
complete third agent implementation for patient side chat

### DIFF
--- a/app/client/src/api.js
+++ b/app/client/src/api.js
@@ -84,10 +84,10 @@ export const aiService = {
       body: JSON.stringify({ query, patientIds }),
     });
   },
-  querySelf: async (query) => {
+  querySelf: async (query, conversationHistory = []) => {
     return await fetchWithAuth(`${apiConfig.endpoints.ai}/patient-self-query`, {
       method: "POST",
-      body: JSON.stringify({ query }),
+      body: JSON.stringify({ query, conversationHistory }),
     });
   },
 };

--- a/app/client/src/pages/PatientChat.js
+++ b/app/client/src/pages/PatientChat.js
@@ -148,6 +148,14 @@ function SelfResultCard({ result }) {
   const [suggestionsOpen, setSuggestionsOpen] = useState(true);
   const [downloadingId, setDownloadingId] = useState(null);
   const [viewingRec, setViewingRec] = useState(null);
+  const [responseOpen, setResponseOpen] = useState(true);
+
+  const TRIAGE_LABELS = {
+    "TIER 1": "Emergency",
+    "TIER 2": "Urgent",
+    "TIER 3": "Semi-Urgent",
+    "TIER 4": "Non-Urgent",
+  };
 
   const handleDownload = async (rec) => {
     if (rec.type !== "file") return;
@@ -173,38 +181,191 @@ function SelfResultCard({ result }) {
     return <Alert severity="error" sx={{ mb: 1 }}>{result.error}</Alert>;
   }
 
+  const hasContent =
+    result.emergency ||
+    result.patientResponse ||
+    result.summary ||
+    result.citedRecords?.length > 0 ||
+    result.suggestions?.length > 0;
+
+  if (!hasContent) {
+    return (
+      <Alert severity="info" sx={{ mb: 1 }}>
+        No response could be generated. Please try rephrasing your question.
+      </Alert>
+    );
+  }
+
   return (
     <Paper variant="outlined" sx={{ mb: 2, borderRadius: 2, overflow: "hidden", borderColor: "divider" }}>
 
-      {/* Summary */}
-      <Box sx={{ px: 2.5, py: 1 }}>
-        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer", py: 0.5 }} onClick={() => setSummaryOpen((o) => !o)}>
-          <Typography variant="body2" fontWeight={600} color="text.secondary" sx={{ textTransform: "uppercase", fontSize: "0.7rem", letterSpacing: 0.8 }}>
-            Clinical Summary
-          </Typography>
-          <IconButton size="small">{summaryOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}</IconButton>
-        </Box>
-        <Collapse in={summaryOpen}>
-          {typeof result.summary === "object" && result.summary !== null ? (
-            <Box sx={{ pb: 1.5 }}>
-              {Object.entries(result.summary).map(([key, value]) => (
-                <Box key={key} sx={{ mb: 1 }}>
-                  <Typography variant="caption" fontWeight={600} color="text.secondary" sx={{ textTransform: "uppercase", fontSize: "0.65rem", letterSpacing: 0.8 }}>
-                    {key}
+      {result.emergency && (
+        <Alert severity="error" icon={false} sx={{ m: 2, borderRadius: 1.5 }}>
+          <Typography variant="body2" fontWeight={700} gutterBottom>⚠️ Emergency</Typography>
+          <Typography variant="body2">{result.emergencyMessage}</Typography>
+        </Alert>
+      )}
+
+      {result.patientResponse && (
+        <Box sx={{ px: 2.5, py: 1, bgcolor: "primary.main", color: "primary.contrastText", borderRadius: "8px 8px 0 0" }}>
+          <Box
+            sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer", py: 0.5 }}
+            onClick={() => setResponseOpen((o) => !o)}
+          >
+            <Typography variant="body2" fontWeight={700} sx={{ fontSize: "0.75rem", letterSpacing: 0.6, textTransform: "uppercase" }}>
+              AI Response
+            </Typography>
+            <IconButton size="small" sx={{ color: "primary.contrastText" }}>
+              {responseOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+            </IconButton>
+          </Box>
+          <Collapse in={responseOpen}>
+            <Box sx={{ pb: 1.5, display: "flex", flexDirection: "column", gap: 1 }}>
+
+              {/* Triage chip */}
+              {result.patientResponse.triageTier && (
+                <Chip
+                  size="small"
+                  label={TRIAGE_LABELS[result.patientResponse.triageTier] ?? result.patientResponse.triageTier}
+                  sx={{
+                    alignSelf: "flex-start",
+                    fontWeight: 700,
+                    fontSize: "0.65rem",
+                    color: "white",
+                    bgcolor:
+                      result.patientResponse.triageTier === "TIER 1" ? "error.main" :
+                        result.patientResponse.triageTier === "TIER 2" ? "warning.main" :
+                          result.patientResponse.triageTier === "TIER 3" ? "info.main" :
+                            "success.main",
+                  }}
+                />
+              )}
+
+              {/* Emergency fallback */}
+              {result.patientResponse.response?.EmergencyMessage && (
+                <Alert severity="error" sx={{ mt: 0.5 }}>
+                  {result.patientResponse.response.EmergencyMessage}
+                </Alert>
+              )}
+
+              {/* Acknowledgement */}
+              {result.patientResponse.response?.Acknowledgement && (
+                <Typography variant="body2" sx={{ lineHeight: 1.7, color: "primary.contrastText" }}>
+                  {result.patientResponse.response.Acknowledgement}
+                </Typography>
+              )}
+
+              {/* Symptom Assessment */}
+              {result.patientResponse.response?.SymptomAssessment && (
+                <Box>
+                  <Typography variant="caption" sx={{ fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.6, opacity: 0.75 }}>
+                    Assessment
                   </Typography>
-                  <Typography variant="body2" sx={{ lineHeight: 1.7, whiteSpace: "pre-wrap" }}>
-                    {Array.isArray(value) ? value.join(", ") : String(value || "Not mentioned")}
+                  <Typography variant="body2" sx={{ lineHeight: 1.7 }}>
+                    {result.patientResponse.response.SymptomAssessment}
                   </Typography>
                 </Box>
-              ))}
+              )}
+
+              {/* Possible Causes */}
+              {result.patientResponse.response?.PossibleCauses && (
+                <Box>
+                  <Typography variant="caption" sx={{ fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.6, opacity: 0.75 }}>
+                    Possible Causes
+                  </Typography>
+                  <Typography variant="body2" sx={{ lineHeight: 1.7 }}>
+                    {result.patientResponse.response.PossibleCauses}
+                  </Typography>
+                </Box>
+              )}
+
+              {/* Recommended Action */}
+              {result.patientResponse.response?.RecommendedAction && (
+                <Box>
+                  <Typography variant="caption" sx={{ fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.6, opacity: 0.75 }}>
+                    Recommended Action
+                  </Typography>
+                  <Typography variant="body2" sx={{ lineHeight: 1.7 }}>
+                    {result.patientResponse.response.RecommendedAction}
+                  </Typography>
+                </Box>
+              )}
+
+              {/* Self Care */}
+              {result.patientResponse.response?.SelfCareGuidance && (
+                <Box>
+                  <Typography variant="caption" sx={{ fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.6, opacity: 0.75 }}>
+                    Self-Care
+                  </Typography>
+                  <Typography variant="body2" sx={{ lineHeight: 1.7 }}>
+                    {result.patientResponse.response.SelfCareGuidance}
+                  </Typography>
+                </Box>
+              )}
+
+              {/* When to Escalate */}
+              {result.patientResponse.response?.WhenToEscalate && (
+                <Alert
+                  severity={result.patientResponse.escalationRequired ? "error" : "warning"}
+                  sx={{ py: 0.5, bgcolor: "transparent", border: "1px solid", borderColor: result.patientResponse.escalationRequired ? "error.light" : "warning.light" }}
+                >
+                  <Typography variant="caption" fontWeight={700} display="block" gutterBottom>
+                    When to Escalate
+                  </Typography>
+                  <Typography variant="body2">{result.patientResponse.response.WhenToEscalate}</Typography>
+                </Alert>
+              )}
+
+              {/* Resources */}
+              {result.patientResponse.response?.ResourcesProvided?.length > 0 && (
+                <Box>
+                  <Typography variant="caption" sx={{ fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.6, opacity: 0.75 }}>
+                    Resources
+                  </Typography>
+                  {result.patientResponse.response.ResourcesProvided.map((r, i) => (
+                    <Typography key={i} variant="body2" sx={{ lineHeight: 1.7 }}>• {r}</Typography>
+                  ))}
+                </Box>
+              )}
+
             </Box>
-          ) : (
-            <Typography variant="body2" sx={{ pb: 1.5, lineHeight: 1.7, whiteSpace: "pre-wrap" }}>
-              {result.summary}
+          </Collapse>
+        </Box>
+      )}
+
+      {result.patientResponse && result.summary && <Divider />}
+
+      {/* Summary */}
+      {result.summary && (
+        <Box sx={{ px: 2.5, py: 1 }}>
+          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer", py: 0.5 }} onClick={() => setSummaryOpen((o) => !o)}>
+            <Typography variant="body2" fontWeight={600} color="text.secondary" sx={{ textTransform: "uppercase", fontSize: "0.7rem", letterSpacing: 0.8 }}>
+              Clinical Summary
             </Typography>
-          )}
-        </Collapse>
-      </Box>
+            <IconButton size="small">{summaryOpen ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}</IconButton>
+          </Box>
+          <Collapse in={summaryOpen}>
+            {typeof result.summary === "object" && result.summary !== null ? (
+              <Box sx={{ pb: 1.5 }}>
+                {Object.entries(result.summary).map(([key, value]) => (
+                  <Box key={key} sx={{ mb: 1 }}>
+                    <Typography variant="caption" fontWeight={600} color="text.secondary" sx={{ textTransform: "uppercase", fontSize: "0.65rem", letterSpacing: 0.8 }}>
+                      {key}
+                    </Typography>
+                    <Typography variant="body2" sx={{ lineHeight: 1.7, whiteSpace: "pre-wrap" }}>
+                      {Array.isArray(value) ? value.join(", ") : String(value || "Not mentioned")}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            ) : (
+              <Typography variant="body2" sx={{ pb: 1.5, lineHeight: 1.7, whiteSpace: "pre-wrap" }}>
+                {result.summary}
+              </Typography>
+            )}
+          </Collapse>
+        </Box>
+      )}
 
       {/* Cited Records */}
       {result.citedRecords?.length > 0 && (
@@ -317,6 +478,8 @@ function SelfResultCard({ result }) {
 SelfResultCard.propTypes = {
   result: PropTypes.shape({
     error: PropTypes.string,
+    emergency: PropTypes.bool,
+    emergencyMessage: PropTypes.string,
     summary: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     citedRecords: PropTypes.arrayOf(PropTypes.shape({
       id: PropTypes.string,
@@ -335,6 +498,22 @@ SelfResultCard.propTypes = {
         })
       ])
     ),
+    patientResponse: PropTypes.shape({
+      requiresRecordLookup: PropTypes.bool,
+      triageTier: PropTypes.string,
+      escalationRequired: PropTypes.bool,
+      followUpSuggested: PropTypes.bool,
+      response: PropTypes.shape({
+        EmergencyMessage: PropTypes.string,
+        Acknowledgement: PropTypes.string,
+        SymptomAssessment: PropTypes.string,
+        PossibleCauses: PropTypes.string,
+        RecommendedAction: PropTypes.string,
+        SelfCareGuidance: PropTypes.string,
+        WhenToEscalate: PropTypes.string,
+        ResourcesProvided: PropTypes.arrayOf(PropTypes.string),
+      }),
+    }),
   }).isRequired,
 };
 
@@ -417,13 +596,27 @@ function PatientChat() {
     const trimmed = query.trim();
     if (!trimmed || loading) return;
 
-    setMessages((prev) => [...prev, { role: "user", text: trimmed }]);
+    const updatedMessages = [...messages, { role: "user", text: trimmed }];
+    setMessages(updatedMessages);
     setQuery("");
     setLoading(true);
 
+    // Build history from the last 6 messages before the one just sent,
+    // excluding result cards which aren't text the agent can use
+    const historyForAgent = updatedMessages
+      .slice(-7, -1)
+      .filter((m) => m.role === "user" || m.role === "ai")
+      .map((m) => ({ role: m.role === "user" ? "user" : "assistant", text: m.text }));
+
     try {
-      const data = await aiService.querySelf(trimmed);
-      setMessages((prev) => [...prev, { role: "result", result: data.result }]);
+      const data = await aiService.querySelf(trimmed, historyForAgent);
+
+      // Agent returned plain text (off-topic, clarification, etc.)
+      if (data.result?.agentMessage) {
+        setMessages((prev) => [...prev, { role: "ai", text: data.result.agentMessage }]);
+      } else {
+        setMessages((prev) => [...prev, { role: "result", result: data.result }]);
+      }
     } catch (err) {
       setMessages((prev) => [
         ...prev,
@@ -473,7 +666,7 @@ function PatientChat() {
             <Avatar sx={{ width: 30, height: 30, bgcolor: "text.primary", color: "#61dafb", fontSize: "0.65rem", fontWeight: "bold", flexShrink: 0 }}>AI</Avatar>
             <Box sx={{ px: 2, py: 1.5, borderRadius: "18px 18px 18px 4px", bgcolor: "background.paper", border: "1px solid", borderColor: "divider", boxShadow: "0 1px 6px rgba(0,0,0,0.08)", display: "flex", alignItems: "center", gap: 1 }}>
               <CircularProgress size={14} thickness={5} sx={{ color: "#61dafb" }} />
-              <Typography variant="body2" color="text.secondary">Analyzing your records…</Typography>
+              <Typography variant="body2" color="text.secondary">Processing your question…</Typography>
             </Box>
           </Box>
         )}

--- a/app/server/routes/aiAgent.js
+++ b/app/server/routes/aiAgent.js
@@ -282,21 +282,85 @@ router.post("/query", async (req, res) => {
 // POST /api/ai/patient-self-query
 // Body: { query: string }
 // Patients query their own records only.
+// Agent 3 decides whether record lookup is needed.
 // ============================================
 router.post("/patient-self-query", async (req, res) => {
   const patientUid = req.user.sub;
   const userRoles = req.user.roles || [];
-  const { query } = req.body;
+  const { query, conversationHistory = [] } = req.body;
 
   if (!userRoles.includes("Patient")) {
     return res.status(403).json({ error: "Only patients can use this endpoint" });
   }
-
   if (!query?.trim()) {
     return res.status(400).json({ error: "query is required" });
   }
 
+  // ── Emergency pre-check ───────────────────────────────────────────────────
+  const EMERGENCY_KEYWORDS = [
+    "chest pain", "can't breathe", "cannot breathe", "heart attack",
+    "stroke", "unconscious", "overdose", "suicidal", "kill myself",
+    "severe bleeding", "seizure", "anaphylaxis", "allergic reaction",
+  ];
+  if (EMERGENCY_KEYWORDS.some((kw) => query.toLowerCase().includes(kw))) {
+    return res.json({
+      ok: true,
+      result: {
+        patientUid,
+        emergency: true,
+        emergencyMessage:
+          "This sounds like it could be a medical emergency. Please call 911 immediately " +
+          "or have someone take you to the nearest emergency room. Do not drive yourself. " +
+          "I am an AI assistant and cannot provide emergency medical care.",
+      },
+    });
+  }
+
   try {
+    // ── Phase 1: Agent 3 — intent detection + general health response ─────────
+    let phase1Response = null;
+    let phase1RawMessage = null;
+    try {
+      const { parsed, rawMessage } = await invokeAgent(
+        process.env.AWS_AGENT3_ID,
+        process.env.AWS_AGENT3_ALIAS_ID,
+        `patient-intent-${patientUid}-${Date.now()}`,
+        JSON.stringify({
+          patientMessage: query,
+          sessionContext: {
+            conversationHistory,
+          },
+        })
+      );
+      phase1Response = parsed;
+      phase1RawMessage = rawMessage;
+    } catch (err) {
+      console.error("Agent 3 phase 1 failed:", err.message);
+    }
+
+    // Agent 3 returned plain text instead of JSON (off-topic, clarification, etc.)
+    if (!phase1Response && phase1RawMessage) {
+      return res.json({
+        ok: true,
+        result: {
+          patientUid,
+          agentMessage: phase1RawMessage,
+        },
+      });
+    }
+
+    // General question only — return Agent 3 response, skip record pipeline
+    if (!phase1Response?.requiresRecordLookup) {
+      return res.json({
+        ok: true,
+        result: {
+          patientUid,
+          patientResponse: phase1Response,
+        },
+      });
+    }
+
+    // ── Phase 2: Record pipeline — Agents 1 and 2 ─────────────────────────────
     let records;
     try {
       records = await fetchPatientRecords(patientUid);
@@ -305,7 +369,6 @@ router.post("/patient-self-query", async (req, res) => {
       return res.status(500).json({ error: "Failed to fetch your records" });
     }
 
-    // ── Agent 1: Clinical Summary ──────────────────────────
     let summaryResult;
     try {
       const { parsed, rawMessage } = await invokeAgent(
@@ -317,7 +380,6 @@ router.post("/patient-self-query", async (req, res) => {
           records: records.map((r) => ({ id: r.id, content: r.content })),
         })
       );
-
       if (!parsed || !validateSummaryResult(parsed)) {
         return res.json({
           ok: true,
@@ -327,7 +389,6 @@ router.post("/patient-self-query", async (req, res) => {
           },
         });
       }
-
       summaryResult = parsed;
     } catch (err) {
       console.error(`Agent 1 failed for ${patientUid}:`, err.message);
@@ -340,7 +401,6 @@ router.post("/patient-self-query", async (req, res) => {
     const safeCitedRecordIDs = Array.isArray(citedRecordIDs)
       ? citedRecordIDs.map(String).filter((id) => validRecordIds.has(id))
       : [];
-
     const citedRecords = records
       .filter((r) => safeCitedRecordIDs.includes(String(r.id)))
       .map((r) => ({
@@ -350,18 +410,13 @@ router.post("/patient-self-query", async (req, res) => {
         uploadedAt: r.uploadedAt,
       }));
 
-    // ── Agent 2: Healthcare Suggestions ───────────────────
     let suggestionsResult;
     try {
       const { parsed } = await invokeAgent(
         process.env.AWS_AGENT2_ID,
         process.env.AWS_AGENT2_ALIAS_ID,
         `suggestions-${patientUid}-${Date.now()}`,
-        JSON.stringify({
-          summary,
-          patientAge: null,
-          knownConditions: [],
-        })
+        JSON.stringify({ summary, patientAge: null, knownConditions: [] })
       );
       suggestionsResult = parsed || { suggestions: [] };
     } catch (err) {
@@ -369,10 +424,18 @@ router.post("/patient-self-query", async (req, res) => {
       suggestionsResult = { suggestions: [] };
     }
 
+    // Only surface Agent 3's phase 1 response if it contains substantive
+    // clinical content — not just acknowledgement or record-retrieval placeholder text.
+    const hasGeneralContent =
+      phase1Response?.response?.SymptomAssessment ||
+      phase1Response?.response?.PossibleCauses ||
+      phase1Response?.response?.SelfCareGuidance;
+
     res.json({
       ok: true,
       result: {
         patientUid,
+        patientResponse: hasGeneralContent ? phase1Response : null,
         summary,
         citedRecords,
         suggestions: suggestionsResult.suggestions || [],


### PR DESCRIPTION
# Pull Request — SAACGAS

## Summary
- Summary: Implements Agent 3 (Patient Communication Agent) into the patient self-query pipeline, adding intent-based routing so general health questions bypass record lookup, conversation history context for multi-turn coherence, and graceful handling of off-topic plain-text agent responses.

## Related issue(s)
- Closes #84 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Tests
- [ ] Research/Experiment
- [ ] Other: ______

---

## Security & Privacy Impact (required)

- **Does this change affect** authentication, authorization, encryption, or key management?
  - [ ] Yes — explain below
  - [x] No
- **Does this change process or store user data, model outputs, or secrets?**
  - [x] Yes — explain below
  - [ ] No

If Yes to either: describe what changed and why, list new secrets/keys (if any) and where/how they are stored, and provide mitigation steps and test evidence.

**Security notes / mitigations:**
- Threat model changes (brief): Agent 3 is invoked before any record lookup occurs. On the general question path, no PHI is fetched or transmitted — the pipeline exits after Agent 3's phase 1 response. On the record path, Agent 3's phase 1 response is returned to the client without record context, and Agent 1/2 output is never forwarded to Agent 3, preserving the PHI boundary established by the two-agent summarization pipeline. Up to 6 prior message turns are included in the Agent 3 payload as conversationHistory. Only role: "user" and role: "ai" messages are forwarded — result cards containing clinical summaries and cited records are explicitly excluded from history to prevent PHI from being re-transmitted to Agent 3 in subsequent turns.
- Cryptography used / changed (algorithms, params)
- Secrets handling and rotation plan: AWS_AGENT3_ID and AWS_AGENT3_ALIAS_ID added to server .env. These are AWS Bedrock agent identifiers with no patient data access on their own — they are used only to invoke the agent via the existing credentialed BedrockAgentRuntimeClient.
- Logging/observability changes that affect privacy
