### PR TITLE
#101 prod db fix provider selection

### DIFF
--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7251,12 +7251,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -7319,9 +7319,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -7330,7 +7330,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -8098,9 +8099,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -12187,6 +12188,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/app/server/routes/provider.js
+++ b/app/server/routes/provider.js
@@ -17,7 +17,10 @@ router.get("/", async (req, res) => {
 });
 
 router.post("/",
-  body("providerId").trim().notEmpty().withMessage("providerId is required").isUUID().withMessage("Invalid providerId format"),
+  body("providerId").trim()
+    .notEmpty().withMessage("providerId is required")
+    .matches(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+    .withMessage("Invalid providerId format"),
   handleValidation,
   async (req, res) => {
     const { providerId } = req.body;

--- a/app/server/services/cognitoService.js
+++ b/app/server/services/cognitoService.js
@@ -36,7 +36,7 @@ export function attrsToObj(attributes) {
 
 export function formatUser(attrs, username) {
     return {
-        sub: username,
+        sub: attrs.sub || username,
         firstName: attrs.given_name || null,
         lastName: attrs.family_name || null,
         email: attrs.email || null,


### PR DESCRIPTION
# Pull Request — SAACGAS

## Summary
- Test new prod DB, fix issues surfaced during migration and first end-to-end run against prod
- Fixed `formatUser` in `cognitoService.js` to prefer `attrs.sub` (real UUID) over `u.Username` (email) so provider selection submits the correct identifier
- Fixed `isUUID()` validator in `provider.js` to accept UUID v7 (AWS Cognito now issues v7 subs) using a version-agnostic regex
- Applied `SECURITY DEFINER` to all Supabase RPC functions in both dev and prod databases so backend calls execute with sufficient privileges

## Related issue(s)
- Closes #101 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Tests
- [ ] Research/Experiment
- [ ] Other: ______

---

## Security & Privacy Impact (required)

- **Does this change affect** authentication, authorization, encryption, or key management?
  - [x] Yes — explain below
  - [ ] No
- **Does this change process or store user data, model outputs, or secrets?**
  - [ ] Yes — explain below
  - [x] No

If Yes to either: describe what changed and why, list new secrets/keys (if any) and where/how they are stored, and provide mitigation steps and test evidence.

**Security notes / mitigations:**
- **Threat model changes:** `SECURITY DEFINER` on Supabase RPC functions means those functions execute as the DB owner rather than the anon role. This is consistent with the existing pattern (all functions were already intended to enforce their own access control logic internally). No new attack surface is introduced — direct table access remains restricted by RLS; all access still flows through the named RPCs.
- **Cryptography used / changed:** None.
- **Secrets handling:** No new secrets introduced. Prod Supabase credentials are stored in `.env` and are not committed. Dev and prod credentials are kept in separate commented-out blocks and swapped manually — consider moving to named env files (`.env.dev` / `.env.prod`) to reduce risk of accidentally pointing at the wrong DB.
- **Logging/observability:** No changes to logging. The `providerId` and `userId` are already logged on provider set errors; no PII is introduced into logs by this change.
