### PR TITLE
Fix ai agent responses, login token expiration handling

### DIFF
--- a/app/client/src/api.js
+++ b/app/client/src/api.js
@@ -13,25 +13,59 @@ const getCsrfToken = () => {
 // ============================================
 async function fetchWithAuth(endpoint, options = {}) {
   const url = `${apiConfig.baseUrlAPI}${endpoint}`;
-  const token = getCsrfToken();
 
-  const headers = {
-    "Content-Type": "application/json",
-    ...options.headers,
-    ...(token ? { "X-CSRF-Token": token } : {}),
+  const token = getCsrfToken();
+  const defaultOptions = {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { "X-CSRF-Token": token } : {}),
+    },
   };
 
-  const response = await fetch(url, {
+  const mergedOptions = {
+    ...defaultOptions,
     ...options,
-    headers,
-    credentials: "include",
-  });
+    headers: { ...defaultOptions.headers, ...(options.headers || {}) },
+  };
 
-  const contentType = response.headers.get("content-type");
-  let data = contentType?.includes("application/json") ? await response.json() : await response.text();
+  let response = await fetch(url, mergedOptions);
+
+  // If the access token has expired, attempt a silent refresh and retry once.
+  if (response.status === 401) {
+    const refreshRes = await fetch(`${apiConfig.baseUrl}/auth/refresh`, {
+      method: "POST",
+      credentials: "include",
+    });
+
+    if (refreshRes.ok) {
+      // Token refreshed — retry the original request with a fresh CSRF token.
+      const newToken = getCsrfToken();
+      const retryOptions = {
+        ...mergedOptions,
+        headers: {
+          ...mergedOptions.headers,
+          ...(newToken ? { "X-CSRF-Token": newToken } : {}),
+        },
+      };
+      response = await fetch(url, retryOptions);
+    } else {
+      // Refresh failed — session is truly expired. Fire an event so
+      // AuthContext can clear state before redirecting, rather than
+      // navigating directly and leaving React state stale.
+      await fetch(`${apiConfig.baseUrl}/auth/logout`, {
+        method: "POST",
+        credentials: "include",
+      });
+      window.dispatchEvent(new CustomEvent("auth:sessionExpired"));
+      return;
+    }
+  }
+
+  const data = response.status !== 204 ? await response.json() : {};
 
   if (!response.ok) {
-    const message = typeof data === "object"
+    const message = response.status !== 204
       ? (data.error || data.message || "Request failed")
       : "Request failed";
     const error = new Error(message);

--- a/app/client/src/context/AuthContext.js
+++ b/app/client/src/context/AuthContext.js
@@ -18,7 +18,7 @@ export function AuthProvider({ children }) {
       const timestamp = new Date().getTime();
       const res = await fetch(`${API}/auth/me?t=${timestamp}`, {
         credentials: "include",
-        headers: { 
+        headers: {
           "Cache-Control": "no-cache, no-store, must-revalidate",
           "Pragma": "no-cache",
           "Expires": "0"
@@ -73,6 +73,15 @@ export function AuthProvider({ children }) {
       }
     };
     initialize();
+  }, []);
+
+  useEffect(() => {
+    const handleSessionExpired = () => {
+      setUser(null);
+      window.location.href = "/login";
+    };
+    window.addEventListener("auth:sessionExpired", handleSessionExpired);
+    return () => window.removeEventListener("auth:sessionExpired", handleSessionExpired);
   }, []);
 
   const login = useCallback(async (email, password) => {
@@ -147,9 +156,9 @@ export function AuthProvider({ children }) {
   const logout = useCallback(async () => {
     setIsLoggingOut(true);
     try {
-      await fetch(`${API}/auth/logout`, { 
-        method: "POST", 
-        credentials: "include" 
+      await fetch(`${API}/auth/logout`, {
+        method: "POST",
+        credentials: "include"
       });
     } catch (err) {
       console.warn("Logout request failed:", err);

--- a/app/client/src/pages/PatientChat.js
+++ b/app/client/src/pages/PatientChat.js
@@ -603,10 +603,45 @@ function PatientChat() {
 
     // Build history from the last 6 messages before the one just sent,
     // excluding result cards which aren't text the agent can use
+    // Build history from the last 6 messages before the one just sent.
+    // Result cards are serialized into a text summary so Agent 3 has the
+    // full conversational context it needs to classify follow-up messages.
     const historyForAgent = updatedMessages
       .slice(-7, -1)
-      .filter((m) => m.role === "user" || m.role === "ai")
-      .map((m) => ({ role: m.role === "user" ? "user" : "assistant", text: m.text }));
+      .flatMap((m) => {
+        if (m.role === "user") {
+          return [{ role: "user", text: m.text }];
+        }
+        if (m.role === "ai") {
+          return [{ role: "assistant", text: m.text }];
+        }
+        if (m.role === "result") {
+          const r = m.result;
+          if (!r || r.error) return [];
+          if (r.summary) {
+            const summaryText =
+              typeof r.summary === "string" ? r.summary : JSON.stringify(r.summary);
+            return [{
+              role: "assistant",
+              text: `I provided a clinical summary of your health records. Summary: ${summaryText.slice(0, 400)}`,
+            }];
+          }
+          if (r.patientResponse?.response) {
+            const resp = r.patientResponse.response;
+            const parts = [
+              resp.Acknowledgement,
+              resp.SymptomAssessment,
+              resp.SelfCareGuidance,
+              resp.RecommendedAction,
+              Array.isArray(resp.ResourcesProvided) ? resp.ResourcesProvided.join(" ") : null,
+            ].filter(Boolean);
+            const text = parts.join(" ").trim().slice(0, 500);
+            return text ? [{ role: "assistant", text }] : [];
+          }
+          return [];
+        }
+        return [];
+      });
 
     try {
       const data = await aiService.querySelf(trimmed, historyForAgent);

--- a/app/server/babel.config.cjs
+++ b/app/server/babel.config.cjs
@@ -1,5 +1,11 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ["@babel/preset-env", {
+      targets: { node: "current" }
+    }]
   ],
+  plugins: [
+    ["@babel/plugin-transform-modules-commonjs"],
+    ["babel-plugin-transform-import-meta"]
+  ]
 };

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -33,9 +33,11 @@
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/eslint-parser": "^7.28.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
         "@babel/preset-env": "^7.28.5",
         "@eslint/eslintrc": "^3.3.1",
         "babel-jest": "^30.2.0",
+        "babel-plugin-transform-import-meta": "^2.3.3",
         "cross-env": "^10.1.0",
         "eslint": "^9.39.1",
         "eslint-plugin-react": "^7.37.5",
@@ -5656,6 +5658,20 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-import-meta": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.3.3.tgz",
+      "integrity": "sha512-bbh30qz1m6ZU1ybJoNOhA2zaDvmeXMnGNBMVMDOJ1Fni4+wMBoy/j7MTRVmqAUCIcy54/rEnr9VEBsfcgbpm3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -37,9 +37,11 @@
   "devDependencies": {
     "@babel/core": "^7.28.5",
     "@babel/eslint-parser": "^7.28.5",
+    "@babel/plugin-transform-modules-commonjs": "^7.28.6",
     "@babel/preset-env": "^7.28.5",
     "@eslint/eslintrc": "^3.3.1",
     "babel-jest": "^30.2.0",
+    "babel-plugin-transform-import-meta": "^2.3.3",
     "cross-env": "^10.1.0",
     "eslint": "^9.39.1",
     "eslint-plugin-react": "^7.37.5",

--- a/app/server/routes/aiAgent.js
+++ b/app/server/routes/aiAgent.js
@@ -14,15 +14,21 @@ import { pathToFileURL } from "url";
 const originalWarn = console.warn.bind(console);
 console.warn = (...args) => {
   if (typeof args[0] === "string" &&
-      args[0].includes("UnknownErrorException") &&
-      args[0].includes("Unable to load font data")) return;
+    args[0].includes("UnknownErrorException") &&
+    args[0].includes("Unable to load font data")) return;
   originalWarn(...args);
 };
 
-const _require = createRequire(import.meta.url);
-const STANDARD_FONT_DATA_URL = pathToFileURL(
-  path.join(path.dirname(_require.resolve("pdfjs-dist/package.json")), "standard_fonts", "/")
-).href;
+const STANDARD_FONT_DATA_URL = (() => {
+  try {
+    const _require = createRequire(import.meta.url);
+    return pathToFileURL(
+      path.join(path.dirname(_require.resolve("pdfjs-dist/package.json")), "standard_fonts", "/")
+    ).href;
+  } catch {
+    return "";
+  }
+})();
 
 const router = express.Router();
 

--- a/app/server/routes/aiAgent.js
+++ b/app/server/routes/aiAgent.js
@@ -4,6 +4,25 @@ import { BedrockAgentRuntimeClient, InvokeAgentCommand } from "@aws-sdk/client-b
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import * as db from "../services/supabaseService.js";
 import * as pdfjsLib from "pdfjs-dist/legacy/build/pdf.mjs";
+import { createRequire } from "module";
+import path from "path";
+import { pathToFileURL } from "url";
+
+// Suppress non-fatal font warnings — pdfjs-dist v5 attempts to load
+// Liberation fonts via file:// URL which Node.js fetch does not support.
+// Text extraction is unaffected since disableFontFace is set.
+const originalWarn = console.warn.bind(console);
+console.warn = (...args) => {
+  if (typeof args[0] === "string" &&
+      args[0].includes("UnknownErrorException") &&
+      args[0].includes("Unable to load font data")) return;
+  originalWarn(...args);
+};
+
+const _require = createRequire(import.meta.url);
+const STANDARD_FONT_DATA_URL = pathToFileURL(
+  path.join(path.dirname(_require.resolve("pdfjs-dist/package.json")), "standard_fonts", "/")
+).href;
 
 const router = express.Router();
 
@@ -53,7 +72,11 @@ async function extractTextFromFile(buffer, fileName) {
   if (ext.endsWith(".pdf")) {
     try {
       const uint8Array = new Uint8Array(buffer);
-      const loadingTask = pdfjsLib.getDocument({ data: uint8Array });
+      const loadingTask = pdfjsLib.getDocument({
+        data: uint8Array,
+        standardFontDataUrl: STANDARD_FONT_DATA_URL,
+        disableFontFace: true,
+      });
       const pdf = await loadingTask.promise;
 
       let fullText = "";
@@ -106,16 +129,36 @@ async function invokeAgent(agentId, agentAliasId, sessionId, inputText) {
   }
 
   const jsonStart = fullReply.indexOf("{");
-  const jsonEnd = fullReply.lastIndexOf("}");
+  if (jsonStart === -1) {
+    return { parsed: null, rawMessage: fullReply.trim() };
+  }
 
-  if (jsonStart === -1 || jsonEnd === -1) {
+  // Walk forward from the opening brace to find its matching closing brace,
+  // ignoring any trailing content Agent 3 appends after the JSON object.
+  let depth = 0;
+  let jsonEnd = -1;
+  for (let i = jsonStart; i < fullReply.length; i++) {
+    if (fullReply[i] === "{") depth++;
+    else if (fullReply[i] === "}") {
+      depth--;
+      if (depth === 0) { jsonEnd = i; break; }
+    }
+  }
+
+  if (jsonEnd === -1) {
     return { parsed: null, rawMessage: fullReply.trim() };
   }
 
   try {
-    return { parsed: JSON.parse(fullReply.slice(jsonStart, jsonEnd + 1)), rawMessage: null };
+    const rawJson = fullReply.slice(jsonStart, jsonEnd + 1);
+    return { parsed: JSON.parse(rawJson), rawMessage: null };
   } catch {
-    return { parsed: null, rawMessage: fullReply.trim() };
+    try {
+      const sanitized = sanitizeJsonString(fullReply.slice(jsonStart, jsonEnd + 1));
+      return { parsed: JSON.parse(sanitized), rawMessage: null };
+    } catch {
+      return { parsed: null, rawMessage: fullReply.trim() };
+    }
   }
 }
 
@@ -200,6 +243,24 @@ router.post("/query", async (req, res) => {
         }
 
         // ── Agent 1: Clinical Summary ──────────────────────────
+        // Possessive/browse phrases like "my asthma records" or "show me my files"
+        // cause Agent 1 to narrate instead of returning structured JSON.
+        // Normalize them into a clinical summarization request it can handle.
+        const RECORD_REQUEST_RE = /^(?:(?:show|get|give|list|view|see|check|pull|display)\s+(?:me\s+)?(?:my\s+)?|my\s+)/i;
+
+        let agent1Query = query;
+        if (RECORD_REQUEST_RE.test(query.trim())) {
+          // Strip the possessive/browse prefix, then strip trailing filler words
+          const stripped = query.trim()
+            .replace(RECORD_REQUEST_RE, "")
+            .replace(/\s+(records?|files?|documents?|history|uploads?|data)$/i, "")
+            .trim();
+
+          agent1Query = stripped
+            ? `Please summarize the patient's medical records related to ${stripped}.`
+            : "Please provide a comprehensive clinical summary of the patient's uploaded medical records and documents.";
+        }
+
         let summaryResult;
         try {
           const { parsed, rawMessage } = await invokeAgent(
@@ -207,7 +268,7 @@ router.post("/query", async (req, res) => {
             process.env.AWS_AGENT1_ALIAS_ID,
             `summary-${patientUid}-${Date.now()}`,
             JSON.stringify({
-              query,
+              query: agent1Query,
               records: records.map((r) => ({ id: r.id, content: r.content })),
             })
           );
@@ -335,10 +396,25 @@ router.post("/patient-self-query", async (req, res) => {
     }
 
     if (!phase1Response && phase1RawMessage) {
-      return res.json({
-        ok: true,
-        result: { patientUid, agentMessage: phase1RawMessage },
-      });
+      // invokeAgent failed to parse — attempt one more time on the raw message
+      // in case the agent output valid JSON with surrounding whitespace or text.
+      try {
+        const start = phase1RawMessage.indexOf("{");
+        const end = phase1RawMessage.lastIndexOf("}");
+        if (start !== -1 && end !== -1) {
+          const sanitized = sanitizeJsonString(phase1RawMessage.slice(start, end + 1));
+          phase1Response = JSON.parse(sanitized);
+        }
+      } catch {
+        // still not parseable — fall through to agentMessage
+      }
+
+      if (!phase1Response) {
+        return res.json({
+          ok: true,
+          result: { patientUid, agentMessage: phase1RawMessage },
+        });
+      }
     }
 
     if (!phase1Response?.requiresRecordLookup) {
@@ -357,6 +433,24 @@ router.post("/patient-self-query", async (req, res) => {
       return res.status(500).json({ error: "Failed to fetch your records." });
     }
 
+    // ── Agent 1: Clinical Summary ──────────────────────────
+    // Possessive/browse phrases like "my asthma records" or "show me my files"
+    // cause Agent 1 to narrate instead of returning structured JSON.
+    // Normalize them into a clinical summarization request it can handle.
+    const RECORD_REQUEST_RE = /^(?:(?:show|get|give|list|view|see|check|pull|display)\s+(?:me\s+)?(?:my\s+)?|my\s+)/i;
+
+    let agent1Query = query;
+    if (RECORD_REQUEST_RE.test(query.trim())) {
+      const stripped = query.trim()
+        .replace(RECORD_REQUEST_RE, "")
+        .replace(/\s+(records?|files?|documents?|history|uploads?|data)$/i, "")
+        .trim();
+
+      agent1Query = stripped
+        ? `Please summarize the patient's medical records related to ${stripped}.`
+        : "Please provide a comprehensive clinical summary of the patient's uploaded medical records and documents.";
+    }
+
     let summaryResult;
     try {
       const { parsed, rawMessage } = await invokeAgent(
@@ -364,7 +458,7 @@ router.post("/patient-self-query", async (req, res) => {
         process.env.AWS_AGENT1_ALIAS_ID,
         `summary-${patientUid}-${Date.now()}`,
         JSON.stringify({
-          query,
+          query: agent1Query,
           records: records.map((r) => ({ id: r.id, content: r.content })),
         })
       );


### PR DESCRIPTION
# Pull Request — SAACGAS

## Summary
- Summary: Fix multiple patient chat reliability issues: conversation context loss causing incorrect agent routing, possessive query normalization for Agent 1, PDF font loading errors, JSON parsing failures from Bedrock agent output, and silent session expiry leaving users in a broken authenticated state.

## Related issue(s)
- Closes #114 
- Closes #115 
- Closes #116 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Tests
- [ ] Research/Experiment
- [ ] Other: ______

---

## Security & Privacy Impact (required)

- **Does this change affect** authentication, authorization, encryption, or key management?
  - [x] Yes — explain below
  - [ ] No
- **Does this change process or store user data, model outputs, or secrets?**
  - [x] Yes — explain below
  - [ ] No

If Yes to either: describe what changed and why, list new secrets/keys (if any) and where/how they are stored, and provide mitigation steps and test evidence.

**Security notes / mitigations:**
Threat model changes: The token refresh retry in fetchWithAuth introduces a new automatic re-authentication flow. The retry is bounded to exactly one attempt — a failed refresh fires auth:sessionExpired and terminates, preventing any retry loop against Cognito. The logout call before redirect ensures server-side session invalidation before client state is cleared.
Session expiry handling: Previously, expired tokens caused API calls to fail with Error: Unauthorized while React state still showed the user as authenticated. The fix clears AuthContext user state via a custom DOM event before redirecting to /login, ensuring React never remains in a stale authenticated state.
Conversation history serialization: The historyForAgent change in PatientChat.js includes prior AI result card content in the context sent to Agent 3. This content is derived from the patient's own session and is only ever sent back to their own patient-self-query endpoint, which enforces role-based access control independently. No cross-patient data is introduced.
Query normalization: The agent1Query rewrite transforms possessive phrases before they reach Agent 1. This does not affect authorization — patients can only ever access their own records regardless of the query string passed to Agent 1.
JSON parsing hardening: The invokeAgent brace-counter and sanitizeJsonString fallback only affect parsing of Bedrock's own responses. No user input reaches this code path directly.
Cryptography used / changed: None.
Secrets handling and rotation plan: No new secrets introduced. Existing AWS credentials and Cognito configuration unchanged.
Logging/observability changes that affect privacy: A temporary logger.info("Agent raw reply") debug log was added during diagnosis — confirm this line is removed before merging to avoid logging potentially sensitive Bedrock response content to the server log.
