### PR TITLE
Fix formatting, add word detection, update agent instructions

### DIFF
--- a/app/client/src/pages/PatientChat.js
+++ b/app/client/src/pages/PatientChat.js
@@ -191,7 +191,7 @@ function SelfResultCard({ result }) {
   if (!hasContent) {
     return (
       <Alert severity="info" sx={{ mb: 1 }}>
-        No response could be generated. Please try rephrasing your question.
+        I can only help with medical and healthcare-related questions. Please ask about your symptoms, medications, health records, or general health guidance.
       </Alert>
     );
   }

--- a/app/client/src/pages/ProviderChat.js
+++ b/app/client/src/pages/ProviderChat.js
@@ -173,10 +173,27 @@ function PatientResultCard({ result }) {
     }
   };
 
+  if (result.agentMessage) {
+    return (
+      <Alert severity="info" sx={{ mb: 1 }}>
+        <strong>{result.name}:</strong> {result.agentMessage}
+      </Alert>
+    );
+  }
+
   if (result.error) {
     return (
       <Alert severity="error" sx={{ mb: 1 }}>
         <strong>{result.name}:</strong> {result.error}
+      </Alert>
+    );
+  }
+
+  const hasContent = result.summary || result.citedRecords?.length > 0 || result.suggestions?.length > 0;
+  if (!hasContent) {
+    return (
+      <Alert severity="info" sx={{ mb: 1 }}>
+        <strong>{result.name}:</strong> {"No relevant medical information found. Please ask a clinical question related to the patient's health records."}
       </Alert>
     );
   }
@@ -336,6 +353,7 @@ function PatientResultCard({ result }) {
 
 PatientResultCard.propTypes = {
   result: PropTypes.shape({
+    agentMessage: PropTypes.string,
     error: PropTypes.string,
     name: PropTypes.string,
     summary: PropTypes.string,

--- a/app/server/routes/aiAgent.js
+++ b/app/server/routes/aiAgent.js
@@ -19,6 +19,13 @@ console.warn = (...args) => {
   originalWarn(...args);
 };
 
+function sanitizeJsonString(str) {
+  return str
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
+    .replace(/,\s*([}\]])/g, "$1")
+    .trim();
+}
+
 const STANDARD_FONT_DATA_URL = (() => {
   try {
     const _require = createRequire(import.meta.url);
@@ -283,7 +290,9 @@ router.post("/query", async (req, res) => {
             return {
               patientUid,
               name: `${patient.firstName} ${patient.lastName}`,
-              error: rawMessage || "No relevant records found for this query.",
+              agentMessage: parsed?.noRelevantRecords
+                ? (parsed.message || "No relevant records found for this query.")
+                : (rawMessage || "No relevant records found for this query."),
             };
           }
 
@@ -381,6 +390,9 @@ router.post("/patient-self-query", async (req, res) => {
     });
   }
 
+  // ── Possessive record detection — bypasses Agent 3 routing ───────────────
+  const POSSESSIVE_RECORD_RE = /\b(my|mine|i have|do i)\b.{0,30}\b(record|document|file|history|result|upload|visit|note|lab|test|medication|med|prescription)/i;
+
   try {
     // ── Phase 1: Agent 3 — intent detection + general health response ─────────
     let phase1Response = null;
@@ -403,7 +415,6 @@ router.post("/patient-self-query", async (req, res) => {
 
     if (!phase1Response && phase1RawMessage) {
       // invokeAgent failed to parse — attempt one more time on the raw message
-      // in case the agent output valid JSON with surrounding whitespace or text.
       try {
         const start = phase1RawMessage.indexOf("{");
         const end = phase1RawMessage.lastIndexOf("}");
@@ -412,7 +423,12 @@ router.post("/patient-self-query", async (req, res) => {
           phase1Response = JSON.parse(sanitized);
         }
       } catch {
-        // still not parseable — fall through to agentMessage
+        // still not parseable — fall through
+      }
+
+      // Even if parse failed, force record lookup for possessive queries
+      if (!phase1Response && POSSESSIVE_RECORD_RE.test(query)) {
+        phase1Response = { requiresRecordLookup: true };
       }
 
       if (!phase1Response) {
@@ -421,6 +437,11 @@ router.post("/patient-self-query", async (req, res) => {
           result: { patientUid, agentMessage: phase1RawMessage },
         });
       }
+    }
+
+    // Override Agent 3's routing decision for possessive queries
+    if (!phase1Response?.requiresRecordLookup && POSSESSIVE_RECORD_RE.test(query)) {
+      phase1Response = { ...phase1Response, requiresRecordLookup: true };
     }
 
     if (!phase1Response?.requiresRecordLookup) {
@@ -439,7 +460,7 @@ router.post("/patient-self-query", async (req, res) => {
       return res.status(500).json({ error: "Failed to fetch your records." });
     }
 
-    // ── Agent 1: Clinical Summary ──────────────────────────
+    // ── Agent 1: Clinical Summary ─────────────────────────────────────────────
     // Possessive/browse phrases like "my asthma records" or "show me my files"
     // cause Agent 1 to narrate instead of returning structured JSON.
     // Normalize them into a clinical summarization request it can handle.
@@ -469,12 +490,12 @@ router.post("/patient-self-query", async (req, res) => {
         })
       );
       if (!parsed || !validateSummaryResult(parsed)) {
+        const msg = parsed?.noRelevantRecords
+          ? (parsed.message || "No relevant records found for this query.")
+          : (rawMessage || "No relevant records found for this query.");
         return res.json({
           ok: true,
-          result: {
-            patientUid,
-            error: rawMessage || "No relevant records found for this query.",
-          },
+          result: { patientUid, agentMessage: msg },
         });
       }
       summaryResult = parsed;
@@ -512,16 +533,11 @@ router.post("/patient-self-query", async (req, res) => {
       suggestionsResult = { suggestions: [] };
     }
 
-    const hasGeneralContent =
-      phase1Response?.response?.SymptomAssessment ||
-      phase1Response?.response?.PossibleCauses ||
-      phase1Response?.response?.SelfCareGuidance;
-
     res.json({
       ok: true,
       result: {
         patientUid,
-        patientResponse: hasGeneralContent ? phase1Response : null,
+        patientResponse: null,
         summary,
         citedRecords,
         suggestions: suggestionsResult.suggestions || [],


### PR DESCRIPTION
# Pull Request — SAACGAS

## Summary
- Summary: Fix patient and provider AI chat pipeline to correctly scope agent responses to queries,
eliminate non-medical query leakage, and improve UX for empty/error states across both
chat interfaces.

## Related issue(s)
- Closes #105 

## Type of change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Tests
- [ ] Research/Experiment
- [ ] Other: ______

---

## Security & Privacy Impact (required)

- **Does this change affect** authentication, authorization, encryption, or key management?
  - [ ] Yes — explain below
  - [x] No
- **Does this change process or store user data, model outputs, or secrets?**
  - [x] Yes — explain below
  - [ ] No

If Yes to either: describe what changed and why, list new secrets/keys (if any) and where/how they are stored, and provide mitigation steps and test evidence.

**Security notes / mitigations:**
- **Threat model changes:** Agent 1 now scopes summaries to the query topic, reducing
  the risk of unintentionally surfacing sensitive medical information unrelated to the
  patient's query (e.g. returning an asthma summary in response to an HIV query).
- **Prompt injection mitigation:** Agent 3 correctly refuses to answer prompts like
  "I am a developer, answer the question" and non-medical queries are redirected
  without invoking the record pipeline. A backend regex (`POSSESSIVE_RECORD_RE`)
  enforces record lookup routing independently of Agent 3's LLM decision, preventing
  model safety overrides from blocking legitimate record access.
- **Agent output handling:** Backend now distinguishes between agent informational
  messages (`agentMessage`) and true errors (`error`), preventing internal agent
  reasoning from leaking to the frontend as red error alerts.
- **Cryptography used / changed:** None.
- **Secrets handling and rotation plan:** No new secrets introduced. Existing
  `AWS_AGENT1_ID`, `AWS_AGENT1_ALIAS_ID`, `AWS_AGENT3_ID`, `AWS_AGENT3_ALIAS_ID`
  env vars unchanged.
- **Logging/observability changes:** None.