### PR TITLE
fix CSRF token race condition causing 403 on first navigation

### DIFF
--- a/app/client/src/api.js
+++ b/app/client/src/api.js
@@ -1,12 +1,31 @@
 import { apiConfig } from "./apiConfig.js";
 
-// Helper to get CSRF token from the browser cookie
-const getCsrfToken = () => {
-  const cookie = document.cookie
-    .split("; ")
-    .find((c) => c.startsWith("XSRF-TOKEN="));
-  return cookie ? cookie.split("=")[1] : null;
-};
+let _csrfToken = null;
+let _initPromise = null;
+
+export function initializeApi() {
+  if (_initPromise) {
+    return _initPromise;
+  }
+  _initPromise = fetch(`${apiConfig.baseUrl}/auth/csrf-token`, {
+    credentials: "include",
+  })
+    .then((res) => res.json())
+    .then((data) => {
+      _csrfToken = data.csrfToken;
+    })
+    .catch(() => {});
+  return _initPromise;
+}
+
+export async function refreshCsrfToken() {
+  _initPromise = null;
+  return initializeApi();
+}
+
+function getCsrfToken() {
+  return _csrfToken;
+}
 
 // ============================================
 // Fetch Helper — JSON
@@ -31,7 +50,6 @@ async function fetchWithAuth(endpoint, options = {}) {
 
   let response = await fetch(url, mergedOptions);
 
-  // If the access token has expired, attempt a silent refresh and retry once.
   if (response.status === 401) {
     const refreshRes = await fetch(`${apiConfig.baseUrl}/auth/refresh`, {
       method: "POST",
@@ -39,20 +57,15 @@ async function fetchWithAuth(endpoint, options = {}) {
     });
 
     if (refreshRes.ok) {
-      // Token refreshed — retry the original request with a fresh CSRF token.
-      const newToken = getCsrfToken();
       const retryOptions = {
         ...mergedOptions,
         headers: {
           ...mergedOptions.headers,
-          ...(newToken ? { "X-CSRF-Token": newToken } : {}),
+          ...(getCsrfToken() ? { "X-CSRF-Token": getCsrfToken() } : {}),
         },
       };
       response = await fetch(url, retryOptions);
     } else {
-      // Refresh failed — session is truly expired. Fire an event so
-      // AuthContext can clear state before redirecting, rather than
-      // navigating directly and leaving React state stale.
       await fetch(`${apiConfig.baseUrl}/auth/logout`, {
         method: "POST",
         credentials: "include",
@@ -81,7 +94,6 @@ async function fetchWithAuth(endpoint, options = {}) {
 // ============================================
 async function fetchWithAuthFormData(endpoint, formData) {
   const url = `${apiConfig.baseUrlAPI}${endpoint}`;
-
   const token = getCsrfToken();
   const headers = token ? { "X-CSRF-Token": token } : {};
 
@@ -100,6 +112,28 @@ async function fetchWithAuthFormData(endpoint, formData) {
   }
 
   return data;
+}
+
+// ============================================
+// Fetch with Blob (file downloads)
+// ============================================
+async function fetchWithAuthBlob(endpoint) {
+  const url = `${apiConfig.baseUrlAPI}${endpoint}`;
+  const token = getCsrfToken();
+
+  const response = await fetch(url, {
+    credentials: "include",
+    headers: token ? { "X-CSRF-Token": token } : {},
+  });
+
+  if (!response.ok) {
+    const data = await response.json();
+    const error = new Error(data.error || "Download failed");
+    error.response = { status: response.status, data };
+    throw error;
+  }
+
+  return response.blob();
 }
 
 // ============================================
@@ -169,19 +203,7 @@ export const uploadService = {
   },
 
   downloadFile: async (id) => {
-    const url = `${apiConfig.baseUrlAPI}/upload/download/${id}`;
-    const token = getCsrfToken();
-    const response = await fetch(url, {
-      credentials: "include",
-      headers: token ? { "X-CSRF-Token": token } : {},
-    });
-    if (!response.ok) {
-      const data = await response.json();
-      const error = new Error(data.error || "Download failed");
-      error.response = { status: response.status, data };
-      throw error;
-    }
-    return response.blob();
+    return await fetchWithAuthBlob(`/upload/download/${id}`);
   },
 };
 

--- a/app/client/src/context/AuthContext.js
+++ b/app/client/src/context/AuthContext.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import { createContext, useContext, useState, useEffect, useCallback } from "react";
 import { apiConfig } from "../apiConfig.js";
+import { refreshCsrfToken } from "../api.js";
 
 const AuthContext = createContext(null);
 const API = apiConfig.baseUrl;
@@ -64,7 +65,6 @@ export function AuthProvider({ children }) {
 
     const initialize = async () => {
       try {
-        await fetch(`${API}/auth/csrf-token`, { credentials: "include" });
         await fetchMe();
       } catch (err) {
         console.error("Initialization failed:", err);
@@ -160,6 +160,7 @@ export function AuthProvider({ children }) {
         method: "POST",
         credentials: "include"
       });
+      await refreshCsrfToken();
     } catch (err) {
       console.warn("Logout request failed:", err);
     } finally {

--- a/app/client/src/index.js
+++ b/app/client/src/index.js
@@ -4,6 +4,7 @@ import './index.css';
 import App from './App.js';
 import { AuthProvider } from "./context/AuthContext.js";
 import { ThemeProvider } from "./context/ThemeContext.js";
+import { initializeApi } from "./api.js";
 
 window.addEventListener('error', (e) => {
   if (e.message === 'ResizeObserver loop completed with undelivered notifications.') {
@@ -11,13 +12,15 @@ window.addEventListener('error', (e) => {
   }
 });
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <AuthProvider>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
-    </AuthProvider>
-  </React.StrictMode>
-);
+initializeApi().then(() => {
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(
+    <React.StrictMode>
+      <AuthProvider>
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+      </AuthProvider>
+    </React.StrictMode>
+  );
+});

--- a/app/client/src/pages/SelectProvider.js
+++ b/app/client/src/pages/SelectProvider.js
@@ -24,7 +24,7 @@ function SelectProvider() {
   };
 
   useEffect(() => {
-    if (isLoading) { setLoadingCurrentProvider(true); return; }
+    if (isLoading || !user?.sub) { setLoadingCurrentProvider(true); return; }
     const controller = new AbortController();
     const fetchProviders = async () => {
       try {

--- a/app/client/src/pages/Upload.js
+++ b/app/client/src/pages/Upload.js
@@ -317,201 +317,201 @@ export default function Upload() {
 
   return (
     <>
-    <PrototypeBanner message="This application is a research prototype developed as part of an academic capstone project at Oregon State University. Do not upload real medical records or personal health information. Use synthetic or fictional data only." />
-    <PageCard>
-      <Typography variant="h4" gutterBottom>Upload</Typography>
+      <PrototypeBanner message="This application is a research prototype developed as part of an academic capstone project at Oregon State University. Do not upload real medical records or personal health information. Use synthetic or fictional data only." />
+      <PageCard>
+        <Typography variant="h4" gutterBottom>Upload</Typography>
 
-      <Box sx={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+        <Box sx={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
 
-        {/* ── File Upload Section ─────────────────────────────────────── */}
-        <Box sx={{ flex: 1, minWidth: 300 }}>
-          <Typography variant="h6" gutterBottom>File Upload</Typography>
-          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
-            Allowed: {ALLOWED_LABEL}
-          </Typography>
-          <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: 2, mb: 2 }}>
-            <input
-              type="file" id="file-upload" multiple
-              accept={ALLOWED_EXTENSIONS} style={{ display: "none" }}
-              onChange={handleFileSelect}
-            />
-            <label htmlFor="file-upload">
-              <Button variant="outlined" component="span">Choose Files</Button>
-            </label>
-            <Button
-              variant="contained" onClick={handleFileUpload}
-              disabled={fileLoading || selectedFiles.length === 0}
-            >
-              {fileLoading ? <CircularProgress size={24} color="inherit" /> : "Upload Files"}
-            </Button>
+          {/* ── File Upload Section ─────────────────────────────────────── */}
+          <Box sx={{ flex: 1, minWidth: 300 }}>
+            <Typography variant="h6" gutterBottom>File Upload</Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+              Allowed: {ALLOWED_LABEL}
+            </Typography>
+            <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: 2, mb: 2 }}>
+              <input
+                type="file" id="file-upload" multiple
+                accept={ALLOWED_EXTENSIONS} style={{ display: "none" }}
+                onChange={handleFileSelect}
+              />
+              <label htmlFor="file-upload">
+                <Button variant="outlined" component="span">Choose Files</Button>
+              </label>
+              <Button
+                variant="contained" onClick={handleFileUpload}
+                disabled={fileLoading || selectedFiles.length === 0}
+              >
+                {fileLoading ? <CircularProgress size={24} color="inherit" /> : "Upload Files"}
+              </Button>
+            </Box>
+
+            {selectedFiles.length > 0 && (
+              <Box sx={{ mb: 2 }}>
+                {selectedFiles.map((file, i) => (
+                  <Chip key={i} label={file.name} onDelete={() => handleRemoveFile(i)} sx={{ mr: 0.5, mb: 0.5 }} />
+                ))}
+              </Box>
+            )}
+
+            {fileMessage && (
+              <Alert severity={fileMessage.type} sx={{ mb: 2 }} onClose={() => setFileMessage(null)}>
+                {fileMessage.text}
+              </Alert>
+            )}
+
+            <Divider sx={{ mb: 2 }} />
+            <Typography variant="subtitle1" gutterBottom>File History</Typography>
+            {loadingHistory ? (
+              <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}><CircularProgress size={24} /></Box>
+            ) : fileHistory.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">No files uploaded yet.</Typography>
+            ) : (
+              <List dense>
+                {fileHistory.map((f) => (
+                  <ListItem
+                    key={f.File_Upload_ID}
+                    disableGutters
+                    secondaryAction={
+                      <Stack direction="row" spacing={0}>
+                        <Tooltip title="View">
+                          <IconButton edge="end" onClick={() => handleViewFile(f)}>
+                            <VisibilityIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Download">
+                          <IconButton
+                            edge="end"
+                            onClick={() => handleDownload(f.File_Upload_ID, f.File_Name)}
+                            disabled={downloadingKey === f.File_Upload_ID}
+                          >
+                            {downloadingKey === f.File_Upload_ID
+                              ? <CircularProgress size={18} />
+                              : <DownloadIcon fontSize="small" />}
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Delete">
+                          <IconButton
+                            edge="end"
+                            color="error"
+                            onClick={() => handleDeleteConfirm("file", f.File_Upload_ID, f.File_Name)}
+                            disabled={deletingId === f.File_Upload_ID}
+                          >
+                            {deletingId === f.File_Upload_ID
+                              ? <CircularProgress size={18} />
+                              : <DeleteIcon fontSize="small" />}
+                          </IconButton>
+                        </Tooltip>
+                      </Stack>
+                    }
+                  >
+                    <ListItemText primary={f.File_Name} secondary={formatDate(f.Upload_Time)} />
+                  </ListItem>
+                ))}
+              </List>
+            )}
           </Box>
 
-          {selectedFiles.length > 0 && (
-            <Box sx={{ mb: 2 }}>
-              {selectedFiles.map((file, i) => (
-                <Chip key={i} label={file.name} onDelete={() => handleRemoveFile(i)} sx={{ mr: 0.5, mb: 0.5 }} />
-              ))}
-            </Box>
-          )}
-
-          {fileMessage && (
-            <Alert severity={fileMessage.type} sx={{ mb: 2 }} onClose={() => setFileMessage(null)}>
-              {fileMessage.text}
-            </Alert>
-          )}
-
-          <Divider sx={{ mb: 2 }} />
-          <Typography variant="subtitle1" gutterBottom>File History</Typography>
-          {loadingHistory ? (
-            <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}><CircularProgress size={24} /></Box>
-          ) : fileHistory.length === 0 ? (
-            <Typography variant="body2" color="text.secondary">No files uploaded yet.</Typography>
-          ) : (
-            <List dense>
-              {fileHistory.map((f) => (
-                <ListItem
-                  key={f.File_Upload_ID}
-                  disableGutters
-                  secondaryAction={
-                    <Stack direction="row" spacing={0}>
-                      <Tooltip title="View">
-                        <IconButton edge="end" onClick={() => handleViewFile(f)}>
-                          <VisibilityIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                      <Tooltip title="Download">
-                        <IconButton
-                          edge="end"
-                          onClick={() => handleDownload(f.File_Upload_ID, f.File_Name)}
-                          disabled={downloadingKey === f.File_Upload_ID}
-                        >
-                          {downloadingKey === f.File_Upload_ID
-                            ? <CircularProgress size={18} />
-                            : <DownloadIcon fontSize="small" />}
-                        </IconButton>
-                      </Tooltip>
-                      <Tooltip title="Delete">
-                        <IconButton
-                          edge="end"
-                          color="error"
-                          onClick={() => handleDeleteConfirm("file", f.File_Upload_ID, f.File_Name)}
-                          disabled={deletingId === f.File_Upload_ID}
-                        >
-                          {deletingId === f.File_Upload_ID
-                            ? <CircularProgress size={18} />
-                            : <DeleteIcon fontSize="small" />}
-                        </IconButton>
-                      </Tooltip>
-                    </Stack>
-                  }
-                >
-                  <ListItemText primary={f.File_Name} secondary={formatDate(f.Upload_Time)} />
-                </ListItem>
-              ))}
-            </List>
-          )}
-        </Box>
-
-        {/* ── Text Upload Section ─────────────────────────────────────── */}
-        <Box sx={{ flex: 1, minWidth: 300 }}>
-          <Typography variant="h6" gutterBottom>Text Upload</Typography>
-          <TextField
-            label="Enter text" multiline minRows={6} maxRows={12}
-            variant="outlined" fullWidth value={text}
-            onChange={(e) => setText(e.target.value)} sx={{ mb: 2 }}
-          />
-          {textMessage && (
-            <Alert severity={textMessage.type} sx={{ mb: 2 }} onClose={() => setTextMessage(null)}>
-              {textMessage.text}
-            </Alert>
-          )}
-          <Button
-            variant="contained" onClick={handleTextUpload}
-            disabled={textLoading || !text.trim()} sx={{ mb: 3 }}
-          >
-            {textLoading ? <CircularProgress size={24} color="inherit" /> : "Save Text"}
-          </Button>
-
-          <Divider sx={{ mb: 2 }} />
-          <Typography variant="subtitle1" gutterBottom>Text History</Typography>
-          {loadingHistory ? (
-            <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}><CircularProgress size={24} /></Box>
-          ) : textHistory.length === 0 ? (
-            <Typography variant="body2" color="text.secondary">No text uploaded yet.</Typography>
-          ) : (
-            <List dense>
-              {textHistory.map((t) => (
-                <ListItem
-                  key={t.Text_Upload_ID}
-                  disableGutters
-                  secondaryAction={
-                    <Stack direction="row" spacing={0}>
-                      <Tooltip title="View">
-                        <IconButton edge="end" onClick={() => handleViewText(t)}>
-                          <VisibilityIcon fontSize="small" />
-                        </IconButton>
-                      </Tooltip>
-                      <Tooltip title="Delete">
-                        <IconButton
-                          edge="end"
-                          color="error"
-                          onClick={() => handleDeleteConfirm(
-                            "text",
-                            t.Text_Upload_ID,
-                            t.Text_Content.slice(0, 40) + (t.Text_Content.length > 40 ? "…" : "")
-                          )}
-                          disabled={deletingId === t.Text_Upload_ID}
-                        >
-                          {deletingId === t.Text_Upload_ID
-                            ? <CircularProgress size={18} />
-                            : <DeleteIcon fontSize="small" />}
-                        </IconButton>
-                      </Tooltip>
-                    </Stack>
-                  }
-                >
-                  <ListItemText
-                    primary={t.Text_Content.length > 80 ? t.Text_Content.slice(0, 80) + "…" : t.Text_Content}
-                    secondary={formatDate(t.Upload_Time)}
-                    slotProps={{ primary: { noWrap: true, sx: { maxWidth: 220 } } }}
-                  />
-                </ListItem>
-              ))}
-            </List>
-          )}
-        </Box>
-      </Box>
-
-      {/* ── Dialogs ─────────────────────────────────────────────────── */}
-      {viewTextDialog && (
-        <TextViewDialog item={viewTextDialog} onClose={() => setViewTextDialog(null)} />
-      )}
-      {viewFileDialog && (
-        <FileViewDialog
-          item={viewFileDialog}
-          onClose={handleCloseFileDialog}
-          onDownload={() => handleDownload(viewFileDialog.id, viewFileDialog.fileName)}
-          downloading={downloadingKey === viewFileDialog.id}
-        />
-      )}
-      {confirmDelete && (
-        <Dialog open onClose={() => setConfirmDelete(null)} maxWidth="xs" fullWidth>
-          <DialogTitle>Confirm Delete</DialogTitle>
-          <DialogContent>
-            <Typography>
-              Are you sure you want to permanently delete{" "}
-              <strong>{confirmDelete.label}</strong>? This cannot be undone.
-            </Typography>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setConfirmDelete(null)}>Cancel</Button>
-            <Button variant="contained" color="error" onClick={handleDeleteExecute}>
-              Delete
+          {/* ── Text Upload Section ─────────────────────────────────────── */}
+          <Box sx={{ flex: 1, minWidth: 300 }}>
+            <Typography variant="h6" gutterBottom>Text Upload</Typography>
+            <TextField
+              label="Enter text" multiline minRows={6} maxRows={12}
+              variant="outlined" fullWidth value={text}
+              onChange={(e) => setText(e.target.value)} sx={{ mb: 2 }}
+            />
+            {textMessage && (
+              <Alert severity={textMessage.type} sx={{ mb: 2 }} onClose={() => setTextMessage(null)}>
+                {textMessage.text}
+              </Alert>
+            )}
+            <Button
+              variant="contained" onClick={handleTextUpload}
+              disabled={textLoading || !text.trim()} sx={{ mb: 3 }}
+            >
+              {textLoading ? <CircularProgress size={24} color="inherit" /> : "Save Text"}
             </Button>
-          </DialogActions>
-        </Dialog>
-      )}
-    </PageCard>
+
+            <Divider sx={{ mb: 2 }} />
+            <Typography variant="subtitle1" gutterBottom>Text History</Typography>
+            {loadingHistory ? (
+              <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}><CircularProgress size={24} /></Box>
+            ) : textHistory.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">No text uploaded yet.</Typography>
+            ) : (
+              <List dense>
+                {textHistory.map((t) => (
+                  <ListItem
+                    key={t.Text_Upload_ID}
+                    disableGutters
+                    secondaryAction={
+                      <Stack direction="row" spacing={0}>
+                        <Tooltip title="View">
+                          <IconButton edge="end" onClick={() => handleViewText(t)}>
+                            <VisibilityIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Delete">
+                          <IconButton
+                            edge="end"
+                            color="error"
+                            onClick={() => handleDeleteConfirm(
+                              "text",
+                              t.Text_Upload_ID,
+                              t.Text_Content.slice(0, 40) + (t.Text_Content.length > 40 ? "…" : "")
+                            )}
+                            disabled={deletingId === t.Text_Upload_ID}
+                          >
+                            {deletingId === t.Text_Upload_ID
+                              ? <CircularProgress size={18} />
+                              : <DeleteIcon fontSize="small" />}
+                          </IconButton>
+                        </Tooltip>
+                      </Stack>
+                    }
+                  >
+                    <ListItemText
+                      primary={t.Text_Content.length > 80 ? t.Text_Content.slice(0, 80) + "…" : t.Text_Content}
+                      secondary={formatDate(t.Upload_Time)}
+                      slotProps={{ primary: { noWrap: true, sx: { maxWidth: 220 } } }}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            )}
+          </Box>
+        </Box>
+
+        {/* ── Dialogs ─────────────────────────────────────────────────── */}
+        {viewTextDialog && (
+          <TextViewDialog item={viewTextDialog} onClose={() => setViewTextDialog(null)} />
+        )}
+        {viewFileDialog && (
+          <FileViewDialog
+            item={viewFileDialog}
+            onClose={handleCloseFileDialog}
+            onDownload={() => handleDownload(viewFileDialog.id, viewFileDialog.fileName)}
+            downloading={downloadingKey === viewFileDialog.id}
+          />
+        )}
+        {confirmDelete && (
+          <Dialog open onClose={() => setConfirmDelete(null)} maxWidth="xs" fullWidth>
+            <DialogTitle>Confirm Delete</DialogTitle>
+            <DialogContent>
+              <Typography>
+                Are you sure you want to permanently delete{" "}
+                <strong>{confirmDelete.label}</strong>? This cannot be undone.
+              </Typography>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setConfirmDelete(null)}>Cancel</Button>
+              <Button variant="contained" color="error" onClick={handleDeleteExecute}>
+                Delete
+              </Button>
+            </DialogActions>
+          </Dialog>
+        )}
+      </PageCard>
     </>
   );
 }

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -24,7 +24,7 @@ const generalLimiter = rateLimit({
   max: 100,
   standardHeaders: true,
   legacyHeaders: false,
-  skip: () => process.env.NODE_ENV === "test",
+  skip: () => process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development",
   message: { error: "Too many requests, please try again later." },
 });
 
@@ -33,7 +33,7 @@ const authLimiter = rateLimit({
   max: 10,
   standardHeaders: true,
   legacyHeaders: false,
-  skip: (req, res) => process.env.NODE_ENV === "test",
+  skip: () => process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development",
   skipSuccessfulRequests: true,
   message: { error: "Too many attempts, please try again later." },
 });


### PR DESCRIPTION
# Pull Request — SAACGAS

## Summary
- Summary: Fixes a CSRF token race condition that caused 403 errors on first navigation by moving token initialization to a module-level singleton in api.js, called before React mounts.

## Related issue(s)
- Closes #128 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Tests
- [ ] Research/Experiment
- [ ] Other: ______

---

## Security & Privacy Impact (required)

- **Does this change affect** authentication, authorization, encryption, or key management?
  - [x] Yes — explain below
  - [ ] No
- **Does this change process or store user data, model outputs, or secrets?**
  - [x] Yes — explain below
  - [ ] No

The CSRF double-submit cookie pattern is the primary protection against cross-site request forgery for all authenticated API calls. This fix changes when and how the CSRF token is initialized.


**Security notes / mitigations:**
- Threat model changes: The CSRF token is now fetched once before React mounts via `initializeApi()` in `index.js`, stored in a module-level variable, and refreshed after logout. This closes a window where requests could fire before the token was ready, which previously caused silent failures rather than a security vulnerability — but ensures the protection is always active.
- Cryptography used / changed: None. CSRF token generation on the server (`crypto.randomBytes(32)`) is unchanged.
- Secrets handling: The CSRF token is stored in a module-level JS variable (`_csrfToken`) and the `XSRF-TOKEN` cookie. Neither is `httpOnly` by design (the double-submit pattern requires client readability). Token is invalidated and refreshed on every logout via `refreshCsrfToken()`.
- Logging/observability: Rate limiting is now disabled in development (`NODE_ENV=development`) to prevent false positives during local testing. Production rate limiting is unchanged.
